### PR TITLE
Don't check for the presence of libtool *.la files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,6 @@ test:
         - test -f $PREFIX/lib/libcairomm-1.0.a
         - test -f $PREFIX/lib/libcairomm-1.0.so          # [linux]
         - test -f $PREFIX/lib/libcairomm-1.0.dylib       # [osx]
-        - test -f $PREFIX/lib/libcairomm-1.0.la
 
 about:
     home: http://cairographics.org/


### PR DESCRIPTION
I think that newer versions of conda-build delete these files automatically